### PR TITLE
Accented chars support on JSONEncoder escapeString function

### DIFF
--- a/src/com/adobe/serialization/json/JSONEncoder.as
+++ b/src/com/adobe/serialization/json/JSONEncoder.as
@@ -164,7 +164,7 @@ package com.adobe.serialization.json
 					default: // everything else
 						
 						// check for a control character and escape as unicode
-						if ( ch < ' ' )
+						if ( ch < ' ' || ch > '}')
 						{
 							// get the hex digit(s) of the character (either 1 or 2 digits)
 							var hexCode:String = ch.charCodeAt( 0 ).toString( 16 );


### PR DESCRIPTION
![Alt text](https://d3nwyuy0nl342s.cloudfront.net/img/0bcc4576ad9210ec5a100baa95412402be325c71/687474703a2f2f692e696d6775722e636f6d2f53455169542e6a7067)

Added accented chars support as stated on the bug (included fix)
https://github.com/mikechambers/as3corelib/issues/128
