### PR TITLE
URI.as bug fixes

### DIFF
--- a/src/com/adobe/net/URI.as
+++ b/src/com/adobe/net/URI.as
@@ -280,7 +280,7 @@ package com.adobe.net
 					// we probably parsed a C:\ type path or no scheme
 					return false;
 				}
-				else if (verifyAlpha(_scheme) == false)
+				else if (verifyScheme(_scheme) == false)
 					return false;  // Scheme contains bad characters
 			}
 			
@@ -432,6 +432,14 @@ package com.adobe.net
 					// Trim off the "//"
 					baseURI = baseURI.substr(2, baseURI.length - 2);
 				}
+				else if (_scheme == "app" || _scheme == "app-storage")
+				{
+					/* This is an AIR local file URI scheme. It doesn't appear to be heirarchical
+					due to the single slash, but we can treat it as such. It's really
+					a fancy file:// URI relative to one of the special directories used
+					by AIR for local data storage. */
+					_nonHierarchical = "";
+				}
 				else
 				{
 					// This is a non-hierarchical URI like "mailto:bob@mail.com"
@@ -567,17 +575,24 @@ package com.adobe.net
 		
 		/**
 		 * @private
-		 * Checks if the given string only contains a-z or A-Z.
+		 * Checks if the given string only contains characters
+		 * valid for a URI scheme as per RFC 3986.
+		 * 
+		 * http://tools.ietf.org/html/rfc3986
+		 * 
+		 * Must begin with a letter, and them contain any number
+		 * of letters, numbers, or "+", "-", or "."
+		 * 
 		 */
-		protected function verifyAlpha(str:String) : Boolean
+		public static function verifyScheme(str:String) : Boolean
 		{
-			var pattern:RegExp = /[^a-z]/;
+			var pattern:RegExp = /[a-z][a-z0-9.+\-]*/;
 			var index:int;
 			
 			str = str.toLowerCase();
 			index = str.search(pattern);
 			
-			if (index == -1)
+			if (index != -1)
 				return true;
 			else
 				return false;

--- a/src/com/adobe/net/URI.as
+++ b/src/com/adobe/net/URI.as
@@ -586,7 +586,7 @@ package com.adobe.net
 		 */
 		public static function verifyScheme(str:String) : Boolean
 		{
-			var pattern:RegExp = /[a-z][a-z0-9.+\-]*/;
+			var pattern:RegExp = /^[a-z][a-z0-9.+\-]*/;
 			var index:int;
 			
 			str = str.toLowerCase();

--- a/src/com/adobe/net/URI.as
+++ b/src/com/adobe/net/URI.as
@@ -1457,7 +1457,7 @@ package com.adobe.net
 				return false;
 		
 			// Compare the extensions ignoring case
-			if (compareStr(thisExtension, extension, false) == 0)
+			if (compareStr(thisExtension, extension, false))
 				return true;
 			else
 				return false;

--- a/tests/src/com/adobe/net/URITest.as
+++ b/tests/src/com/adobe/net/URITest.as
@@ -573,6 +573,30 @@ package com.adobe.net
 			assertTrue("Relative path verification failed.", test1.getRelation(test2) == URI.EQUAL);
 		}
 		
+		public function testFileType() : void
+		{
+			const TEST_EXTENSION : String = "xml";
+			const TEST_EXTENSION_OTHER : String = "csv";
+			const TEST_EXTENSION_UPPERCASE : String = "XML";
+			
+			const TEST_FILENAME : String = "foo.xml";
+			const TEST_URI : String = "http://adobe.com/foo.xml";
+			
+			// try with a full URI
+			var http_uri : URI = new URI( TEST_URI );
+			
+			assertFalse( "URI should NOT match different extension.", http_uri.isOfFileType( TEST_EXTENSION_OTHER ) );
+			assertTrue( "URI should have matched test extension.", http_uri.isOfFileType( TEST_EXTENSION ) );
+			assertTrue( "URI should have matched uppercase test extension.", http_uri.isOfFileType( TEST_EXTENSION_UPPERCASE ) );
+			
+			// try with just a filename
+			var file_uri : URI = new URI( TEST_FILENAME );
+			
+			assertFalse( "URI should NOT match different extension.", file_uri.isOfFileType( TEST_EXTENSION_OTHER ) );
+			assertTrue( "URI should have matched test extension.", file_uri.isOfFileType( TEST_EXTENSION ) );
+			assertTrue( "URI should have matched uppercase test extension.", file_uri.isOfFileType( TEST_EXTENSION_UPPERCASE ) );
+		}
+		
 		// Interface for IURIResolver
 		public function resolve(uri:URI) : URI
 		{

--- a/tests/src/com/adobe/net/URITest.as
+++ b/tests/src/com/adobe/net/URITest.as
@@ -126,6 +126,17 @@ package com.adobe.net
 				mt, mt, mt, mt, mt,	"/images", "blah:somequery", "anchor", mt);
 		}
 		
+		public function testSpecialAIRParsing() : void
+		{
+			var mt:String = "";
+			
+			// Test Adobe AIR special URIs for embedded assets and local temp files
+			parseAndTest("app:/my/path/file.html",
+				"app",	mt, mt, mt, mt, "/my/path/file.html", mt, mt, mt);
+			
+			parseAndTest("app-storage:/my/path/file.html",
+				"app-storage",	mt, mt, mt, mt, "/my/path/file.html", mt, mt, mt);
+		}
 		
 		public function testUnknownParsing() : void
 		{
@@ -287,7 +298,8 @@ package com.adobe.net
 			assertTrue("URI is invalid.", uri.isValid());
 			
 			// Make sure we get out what we expect
-			assertEquals("URI.toString() should output what we input.", expectedURI, uri.toString());
+			var actualURI : String = uri.toString();
+			assertEquals("URI.toString() should output what we input.", expectedURI, actualURI);
 			
 			if (uri.isHierarchical())
 			{
@@ -328,7 +340,8 @@ package com.adobe.net
 			var uri:URI = new URI(inURI);
 		
 			// Make sure we get out what we put in.
-			assertEquals("URI.toString() should output what we input.", inURI, uri.toString());
+			var actualURI : String = uri.toString();
+			assertEquals("URI.toString() should output what we input.", inURI, actualURI);
 		
 			if (uri.isHierarchical())
 			{
@@ -597,6 +610,19 @@ package com.adobe.net
 			assertTrue( "URI should have matched uppercase test extension.", file_uri.isOfFileType( TEST_EXTENSION_UPPERCASE ) );
 		}
 		
+		public function testVerifyScheme() : void
+		{
+			assertTrue( URI.verifyScheme( "HTTP" ) );
+			assertTrue( URI.verifyScheme( "http" ) );
+			assertTrue( URI.verifyScheme( "app-storage" ) );
+			assertTrue( URI.verifyScheme( "git+ssh" ) );
+			assertTrue( URI.verifyScheme( "z39.50s" ) );
+			assertTrue( URI.verifyScheme( "A0K" ) );
+			assertTrue( URI.verifyScheme( "X" ) );
+			
+			assertFalse( URI.verifyScheme( "0" ) );
+		}
+
 		// Interface for IURIResolver
 		public function resolve(uri:URI) : URI
 		{
@@ -608,6 +634,5 @@ package com.adobe.net
 				
 			return uri;
 		}
-		
 	} // end class
 } // end package

--- a/tests/src/com/adobe/net/URITest.as
+++ b/tests/src/com/adobe/net/URITest.as
@@ -138,6 +138,53 @@ package com.adobe.net
 				"app-storage",	mt, mt, mt, mt, "/my/path/file.html", mt, mt, mt);
 		}
 		
+		public function testUnusualSchemes() : void
+		{
+			var mt:String = "";
+			var uri : URI;
+			
+			/* Checks if the given string only contains characters
+			* valid for a URI scheme as per RFC 3986.
+			* 
+			* http://tools.ietf.org/html/rfc3986
+			* 
+			* Must begin with a letter, and them contain any number
+			* of letters, numbers, or "+", "-", or "."
+			*/
+			
+			// May contain plusses
+			parseAndTest("git+ssh://github.com/mikechambers/as3corelib.git",
+				"git+ssh", mt, mt, "github.com", mt, "/mikechambers/as3corelib.git", mt, mt, mt);
+			
+			// May contain periods, and numbers for that matter
+			parseAndTest("z39.50r://test.com/database",
+				"z39.50r", mt, mt, "test.com", mt, "/database", mt, mt, mt);
+
+			// May contain hyphens
+			parseAndTest("view-source:www.test.com/my/path/file.html",
+				"view-source", mt, mt, mt, mt, mt, mt, mt, "www.test.com/my/path/file.html");
+			
+			// Normalize upper case schemes to lowercase.
+			uri = new URI("HTTP://www.test.com/my/path/file.html");
+			assertEquals( "www.test.com", uri.authority );
+			assertEquals( "/my/path/file.html", uri.path );
+			assertEquals( mt, uri.fragment );
+			assertEquals( mt, uri.query );
+
+			// First character of scheme must be an alphabetic character - not valid in these cases
+			uri = new URI("0http://www.test.com/my/path/file.html");
+			assertEquals( "unknown:", uri.toString() );
+
+			uri = new URI(".http://www.test.com/my/path/file.html");
+			assertEquals( "unknown:", uri.toString() );
+			
+			uri = new URI("+http://www.test.com/my/path/file.html");
+			assertEquals( "unknown:", uri.toString() );
+			
+			uri = new URI("-http://www.test.com/my/path/file.html");
+			assertEquals( "unknown:", uri.toString() );
+		}
+		
 		public function testUnknownParsing() : void
 		{
 			var mt:String = "";
@@ -373,7 +420,8 @@ package com.adobe.net
 				uri.query = query;
 				uri.fragment = fragment;
 				
-				assertEquals("URI.toString() should be the same.", uri.toString(), inURI);
+				actualURI = uri.toDisplayString();
+				assertEquals("URI.toString() should be the same.", actualURI, inURI);
 			}
 			else
 			{

--- a/tests/src/com/adobe/net/URITest.as
+++ b/tests/src/com/adobe/net/URITest.as
@@ -667,8 +667,8 @@ package com.adobe.net
 			assertTrue( URI.verifyScheme( "z39.50s" ) );
 			assertTrue( URI.verifyScheme( "A0K" ) );
 			assertTrue( URI.verifyScheme( "X" ) );
-			
 			assertFalse( URI.verifyScheme( "0" ) );
+			assertFalse( URI.verifyScheme( "0ff" ) );
 		}
 
 		// Interface for IURIResolver


### PR DESCRIPTION
Added support for additional URI schemes per RFC 3986[1]. Specifically this patch adds support for three special characters (".", "+", and "-") in the URI scheme that were previously being rejected as invalid.

I also included some special handling for AIR-specific URI schemes (app:/ and app-storage:/), since they're actually hierarchical despite the single slash.

I closed the previous pull request and replaced it with this one, since the branch now has a couple of different fixes for the URI class.

[1] http://tools.ietf.org/html/rfc3986
