### PR TITLE
Fixed vCard parsing bugs and added support for additional address fields

### DIFF
--- a/src/com/adobe/fileformats/vcard/Address.as
+++ b/src/com/adobe/fileformats/vcard/Address.as
@@ -35,13 +35,15 @@ package com.adobe.fileformats.vcard
 	{
 		public var type:String;
 		public var street:String;
+		public var street2:String;
 		public var city:String;
 		public var state:String;
 		public var postalCode:String;
+		public var country:String;
 		
 		public function toString():String
 		{
-			return (street + " " + city + ", " + state + " " + postalCode);
+			return (street + " " + city + ", " + state + " " + postalCode+ " " + country);
 		}
 	}
 }

--- a/src/com/adobe/fileformats/vcard/Email.as
+++ b/src/com/adobe/fileformats/vcard/Email.as
@@ -33,6 +33,7 @@ package com.adobe.fileformats.vcard
 {
 	public class Email
 	{
+		public var isPreferred:Boolean;
 		public var type:String;
 		public var address:String;
 	}

--- a/src/com/adobe/fileformats/vcard/IM.as
+++ b/src/com/adobe/fileformats/vcard/IM.as
@@ -1,0 +1,40 @@
+/*
+Copyright (c) 2008, Adobe Systems Incorporated
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright notice, 
+this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the 
+documentation and/or other materials provided with the distribution.
+
+* Neither the name of Adobe Systems Incorporated nor the names of its 
+contributors may be used to endorse or promote products derived from 
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package com.adobe.fileformats.vcard
+{
+	public class IM
+	{
+		public var isPreferred:Boolean;
+		public var type:String;
+		public var address:String;
+	}
+}

--- a/src/com/adobe/fileformats/vcard/Phone.as
+++ b/src/com/adobe/fileformats/vcard/Phone.as
@@ -33,6 +33,7 @@ package com.adobe.fileformats.vcard
 {
 	public class Phone
 	{
+		public var isPreferred:Boolean;
 		public var type:String;
 		public var number:String;
 	}

--- a/src/com/adobe/fileformats/vcard/VCard.as
+++ b/src/com/adobe/fileformats/vcard/VCard.as
@@ -41,7 +41,9 @@ package com.adobe.fileformats.vcard
 		public var image:ByteArray;
 		public var phones:Array;
 		public var emails:Array;
+		public var ims:Array;
 		public var addresses:Array;
+		public var isCompany:Boolean;
 		
 		public function VCard()
 		{
@@ -49,6 +51,7 @@ package com.adobe.fileformats.vcard
 			phones = new Array();
 			emails = new Array();
 			addresses = new Array();
+			ims = new Array();
 		}
 	}
 }


### PR DESCRIPTION
Added support for multi-line street addresses
Added support for IM addresses
Adding support for preferred phone/email/IM
Fixed bug with parsing address with no street number
Fixed mix NULL Exceptions when parsing files from Outlook
Added support for displayAsCompany (OSX Address Book)
