### PR TITLE
Deprecate the old API and provide an interface that enables migration to the ECMA & Flash 11 standard JSON object.

### DIFF
--- a/src/com/adobe/serialization/json/JSON.as
+++ b/src/com/adobe/serialization/json/JSON.as
@@ -56,9 +56,24 @@ package com.adobe.serialization.json
 		 * @playerversion Flash 9.0
 		 * @tiptext
 		 */
+		[Deprecated(replacement="JSON.stringify")]
 		public static function encode( o:Object ):String
 		{
 			return new JSONEncoder( o ).getString();
+		}
+		
+		/**
+		 * Render the object as a JSON string
+		 * This method is syntactically compatible with the Flash 11 native JSON support.
+		 * 
+		 * @param o The object to create a JSON string for
+		 * @return the JSON string represnetation of o
+		 * @langversion ActionSript 3.0
+		 * @playerversion Flash 9.0
+		 * @see #encode
+		 */
+		public static function stringify( o:Object ) : String {
+			return encode( o );
 		}
 		
 		/**
@@ -76,11 +91,25 @@ package com.adobe.serialization.json
 		 * @playerversion Flash 9.0
 		 * @tiptext
 		 */
+		[Deprecated(replacement="JOSN.parse")]
 		public static function decode( s:String, strict:Boolean = true ):*
 		{
 			return new JSONDecoder( s, strict ).getValue();
 		}
-	
+		
+		/**
+		 * Create an object from a JSON string
+		 * This method is syntactically compatible with Flash 11 native JSON support
+		 * 
+		 * @param s The JSON string respresentation of the object content
+		 * @return a dynamic object with the contents specified by s
+		 * @throw JSONParseError
+		 * @langversion ActionScript 3.0
+		 * @playerversion Flash 9.0
+		 */
+		public static function parse( s:String ):*
+		{
+			return decode( s );
+		}
 	}
-
 }

--- a/tests/src/com/adobe/serialization/json/ComplexClass.as
+++ b/tests/src/com/adobe/serialization/json/ComplexClass.as
@@ -1,0 +1,11 @@
+package com.adobe.serialization.json
+{
+	/**
+	 * @author johnbito
+	 */
+	public class ComplexClass 
+	{
+		public var s : String;
+		public var v : ValueClass;
+	}
+}

--- a/tests/src/com/adobe/serialization/json/JSONTest.as
+++ b/tests/src/com/adobe/serialization/json/JSONTest.as
@@ -535,6 +535,25 @@ package com.adobe.serialization.json
 			assertEquals( 4, count );
 		}
 		
+		public function testEncodeClassInstanceWithValueClass():void
+		{
+			var customObject:ComplexClass = new ComplexClass();
+			var serialized:String;
+			var result:Object;
+			var count:int =0;
+			customObject.s = "string";
+			customObject.v = new ValueClass();
+			serialized = JSON.stringify(customObject);
+			assertTrue( "Has length", serialized.length > 0 );
+			result = JSON.parse(serialized);
+			assertEquals(customObject.s, result.s);
+			assertEquals(customObject.v.toJSON(), result.v);
+			for (serialized in result)
+			{
+				count++;
+			}
+			assertEquals(2, count);
+		}
 	}
 		
 }

--- a/tests/src/com/adobe/serialization/json/ValueClass.as
+++ b/tests/src/com/adobe/serialization/json/ValueClass.as
@@ -1,0 +1,14 @@
+package com.adobe.serialization.json
+{
+	/**
+	 * @author johnbito
+	 */
+	public class ValueClass {
+		public function toJSON(key:*=null) : Object {
+			key;
+			var result:*;
+			result = "VALUE";
+			return result;
+		}
+	}
+}


### PR DESCRIPTION
Implement ability for objects to define serialization by providing toJSON function.
Add relevant test to JSONTest
Add supporting classes to tests/src...json
