### PR TITLE
Serializer ignoring dynamically added properties

### DIFF
--- a/src/com/adobe/serialization/json/JSONEncoder.as
+++ b/src/com/adobe/serialization/json/JSONEncoder.as
@@ -248,42 +248,40 @@ package com.adobe.serialization.json
 		{
 			// create a string to store the object's jsonstring value
 			var s:String = "";
+
+			// the value of o[key] in the loop below - store this 
+			// as a variable so we don't have to keep looking up o[key]
+			// when testing for valid values to convert
+			var value:Object;
 			
-			// determine if o is a class instance or a plain object
-			var classInfo:XML = describeType( o );
-			if ( classInfo.@name.toString() == "Object" )
+			// loop over the keys in the object and add their converted
+			// values to the string
+			for ( var key:String in o )
 			{
-				// the value of o[key] in the loop below - store this 
-				// as a variable so we don't have to keep looking up o[key]
-				// when testing for valid values to convert
-				var value:Object;
+				// assign value to a variable for quick lookup
+				value = o[ key ];
 				
-				// loop over the keys in the object and add their converted
-				// values to the string
-				for ( var key:String in o )
+				// don't add function's to the JSON string
+				if ( value is Function )
 				{
-					// assign value to a variable for quick lookup
-					value = o[ key ];
-					
-					// don't add function's to the JSON string
-					if ( value is Function )
-					{
-						// skip this key and try another
-						continue;
-					}
-					
-					// when the length is 0 we're adding the first item so
-					// no comma is necessary
-					if ( s.length > 0 )
-					{
-						// we've already added an item, so add the comma separator
-						s += ","
-					}
-					
-					s += escapeString( key ) + ":" + convertToString( value );
+					// skip this key and try another
+					continue;
 				}
+				
+				// when the length is 0 we're adding the first item so
+				// no comma is necessary
+				if ( s.length > 0 )
+				{
+					// we've already added an item, so add the comma separator
+					s += ","
+				}
+				
+				s += escapeString( key ) + ":" + convertToString( value );
 			}
-			else // o is a class instance
+			
+			// determine if o is a class instance (as opposed to a plain object)
+			var classInfo:XML = describeType( o );
+			if ( classInfo.@name.toString() != "Object" ) // o is a class instance
 			{
 				// Loop over all of the variables and accessors in the class and 
 				// serialize them along with their values.


### PR DESCRIPTION
The serializer was not including properties that was added dynamically to classes. 

The reason I really want this is that sometimes, the JSON you want to create does not quite correspond to the object you are serializing. In my case, the web service handling the JSON output needed a property called "in". "in" is a reserved keyword in ActionScript, so in my model, I have named it "inPoint". This means that I need this, pre-serialization:

var obj:myObject = myService.getObject();
obj['in'] = obj.inPoint; 
var json:String = JSON.encode(obj);

All good so far, BUT the serializer was not including properties that was added dynamically to classes. This was due to an unnecessarily strict if-clause, which I have now relaxed a bit. 
